### PR TITLE
Release v0.2.0 ✨: Futureproofing, bug fixes, smarter and faster parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tauri-plugin-hwinfo"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["Nikola Ranđelović <contact@nikolchaa.com>"]
 description = "A cross-platform Tauri plugin to fetch CPU, RAM, GPU, and OS info."
@@ -21,6 +21,12 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "2"
 sysinfo = "0.34.2"
 os_info = "3.10.0"
+windows = { version = "0.54", features = [
+  "Win32_Graphics_Dxgi",
+  "Win32_Graphics_Direct3D11",
+  "Win32_System_SystemServices",
+  "Win32_Foundation",
+] }
 
 [build-dependencies]
 tauri-plugin = { version = "2.2.0", features = ["build"] }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # 🧠 tauri-plugin-hwinfo
 
+![License](https://img.shields.io/github/license/nikolchaa/tauri-plugin-hwinfo?color=blue)
+![Crates.io](https://img.shields.io/crates/v/tauri-plugin-hwinfo?color=blue)
+![Crates.io Downloads](https://img.shields.io/crates/d/tauri-plugin-hwinfo?color=blue)
+![npm](https://img.shields.io/npm/v/tauri-plugin-hwinfo?color=blue)
+![npm Downloads](https://img.shields.io/npm/dt/tauri-plugin-hwinfo?color=blue)
+
 A cross-platform Tauri plugin to fetch detailed system hardware information from the user's device, including CPU, RAM, GPU, and OS metadata — all accessible through both Rust and JavaScript/TypeScript APIs.
 
-> ⚠️ **Platform Support**: Desktop-only. Mobile support returns placeholder values.
-
+> ⚠️ **Platform Support**: Desktop-only. Mobile returns placeholder values.
+>
 > ⚠️ **Testing**: Only Windows is tested and confirmed working so far.
 
 ## 🔧 Features
@@ -19,34 +25,54 @@ A cross-platform Tauri plugin to fetch detailed system hardware information from
 
 ### From Crates.io (Rust)
 
-```toml
-[dependencies]
-tauri-plugin-hwinfo = "0.1.0"
+```sh
+cargo add tauri-plugin-hwinfo
 ```
 
-> 🔖 Replace with the latest version from [crates.io](https://crates.io/crates/tauri-plugin-hwinfo)
-
-### From GitHub (pre-release testing)
+### From GitHub (bleeding edge)
 
 ```toml
 [dependencies]
-tauri-plugin-hwinfo = { git = "https://github.com/nikolchaa/tauri-plugin-hwinfo", tag = "v0.1.0" }
+tauri-plugin-hwinfo = { git = "https://github.com/nikolchaa/tauri-plugin-hwinfo" }
 ```
 
-## 🧰 Usage (Rust Backend)
+## 🛠️ Usage (Rust Backend)
+
+### Option 1: Auto-bind commands via invoke_handler (if calling from JS/TS manually)
 
 ```rust
-use tauri_plugin_hwinfo::init;
-
-fn main() {
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
     tauri::Builder::default()
-        .plugin(init())
+        .plugin(tauri_plugin_hwinfo::init())
+        .invoke_handler(tauri::generate_handler![
+            tauri_plugin_hwinfo::get_cpu_info,
+            tauri_plugin_hwinfo::get_gpu_info,
+            tauri_plugin_hwinfo::get_ram_info,
+            tauri_plugin_hwinfo::get_os_info
+        ])
         .run(tauri::generate_context!())
-        .expect("failed to run app");
+        .expect("error while running tauri application");
 }
 ```
 
-⚠️ Add the following permissions to your `src-tauri/capabilities/default.json`
+### Option 2: Plugin-only setup (if using only the frontend API)
+
+```rust
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_hwinfo::init())
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}
+```
+
+> Use Option 1 if you want to manually expose commands to JS via `invoke()`.
+>
+> Use Option 2 if you're only using `tauri-plugin-hwinfo`'s built-in TS API.
+
+Add this to your `src-tauri/capabilities/default.json`:
 
 ```json
 {
@@ -59,13 +85,47 @@ fn main() {
 }
 ```
 
-## 📜 Frontend API (JS/TS)
+## 📜 Output Format
 
-Install via NPM, or link locally if using manually.
+```json
+// CPU Info:
+{
+  "manufacturer": "AuthenticAMD",
+  "model": "AMD Ryzen 9 5900X 12-Core Processor",
+  "maxFrequency": 3701,
+  "threads": 24
+}
+
+// RAM Info:
+{
+  "sizeMb": 32686
+}
+
+// GPU Info:
+{
+  "manufacturer": "Advanced Micro Devices, Inc.",
+  "model": "AMD Radeon RX 6950 XT",
+  "vramMb": 16311,
+  "supportsCuda": false,
+  "supportsVulkan": true
+}
+
+// OS Info:
+{
+  "name": "Windows",
+  "version": "10.0.26100"
+}
+```
+
+## 📌 Frontend API (JS/TS)
+
+Install:
 
 ```sh
 npm i tauri-plugin-hwinfo
 ```
+
+Usage:
 
 ```ts
 import {
@@ -75,8 +135,15 @@ import {
   getOsInfo,
 } from "tauri-plugin-hwinfo";
 
-async function showCpuInfo() {
+async function logSystemInfo() {
   const cpu = await getCpuInfo();
-  console.log(cpu.model);
+  const ram = await getRamInfo();
+  const gpu = await getGpuInfo();
+  const os = await getOsInfo();
+
+  console.log("CPU Info:", cpu);
+  console.log("RAM Info:", ram);
+  console.log("GPU Info:", gpu);
+  console.log("OS Info:", os);
 }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tauri-plugin-hwinfo",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "Nikola Ranđelović <contact@nikolchaa.com>",
   "description": "A cross-platform Tauri plugin to fetch CPU, RAM, GPU, and OS info.",
   "license": "MIT",


### PR DESCRIPTION
# tauri-plugin-hwinfo v0.2.0

🧠 System-level plugin for detecting CPU, RAM, GPU, and OS info in your Tauri app.

**❓ What's Changed**

- ✅ Replaced `dxdiag` with native DirectX API (Windows): accurate and race-free VRAM
- ✅ macOS now reports unified RAM as fallback VRAM
- ✅ Smarter VRAM label parsing on MacOS (`VRAM (Total)`, `VRAM (Dynamic, Max)`, etc.)
- ✅ New README badges, realistic output examples, and docs clarity

This is a patch release with no breaking changes — safe to upgrade.

⚠️ Currently tested on Windows only.